### PR TITLE
Use pin 17 for RPi Pico CS

### DIFF
--- a/examples/ArduinoPico/full_featured/full_featured.ino
+++ b/examples/ArduinoPico/full_featured/full_featured.ino
@@ -9,7 +9,7 @@
 #include "ArducamLink.h"
 #include "Arducam_Mega.h"
 #include "SPI.h"
-const int CS = 7;
+const int CS = 17;
 Arducam_Mega myCAM(CS);
 ArducamLink myUart;
 uint8_t temp             = 0xff;


### PR DESCRIPTION
This is a typo - it should be 17 instead of 7 - the pin definitions look like the following

```
// SPI
#define PIN_SPI_MISO  (16u)
#define PIN_SPI_MOSI  (19u)
#define PIN_SPI_SCK   (18u)
#define PIN_SPI_SS    (17u)
```